### PR TITLE
Bump dependencies

### DIFF
--- a/counter/package.json
+++ b/counter/package.json
@@ -7,12 +7,12 @@
     "hardhat": "^2.9.0"
   },
   "dependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.1.3",
+    "@matterlabs/hardhat-zksync-deploy": "^0.1.5",
     "@matterlabs/hardhat-zksync-solc": "^0.2.4",
     "ethers": "^5.5.2",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4",
-    "zksync-web3": "^0.3.4"
+    "zksync-web3": "^0.4.0"
   },
   "scripts": {
     "start": "hardhat deploy-zksync",


### PR DESCRIPTION
I tried this tutorial but it wouldn't work properly.

Two dependencies are seemed to be old.
* `zksync-web3`
* `@matterlabs/hardhat-zksync-deploy`

```
$ yarn hardhat deploy-zksync
...
  reason: 'processing response error',
  code: 'SERVER_ERROR',
  body: '{"jsonrpc":"2.0","error":{"code":3,"message":"Execution error","data":{"code":104,"message":"Cannot estimate transaction: Insufficient funds. Balance: 0, required: 301720320."}},"id":61}\n',
```

After upgrading this, it seems to works well.